### PR TITLE
'&' used with non-inout argument of type 'JWT<_>'

### DIFF
--- a/Sources/JWTVapor/JWTService.swift
+++ b/Sources/JWTVapor/JWTService.swift
@@ -16,8 +16,8 @@ extension JWTService {
         guard let header = self.header else {
             throw JWTProviderError(identifier: "noHeader", reason: "Cannot sign token with a header", status: .internalServerError)
         }
-        var jwt = JWT.init(header: header, payload: payload)
-        let data = try signer.sign(&jwt)
+        let jwt = JWT.init(header: header, payload: payload)
+        let data = try signer.sign(jwt)
         guard let token = String(data: data, encoding: .utf8) else {
             throw JWTProviderError(
                 identifier: "tokenEncodingFailed",


### PR DESCRIPTION
I get this error when building with the latest JWT 3.0.0:
```
.../.build/checkouts/JWTVapor.git--6738815433567181283/Sources/JWTVapor/JWTService.swift:20:36: error: '&' used with non-inout argument of type 'JWT<_>'
        let data = try signer.sign(&jwt)
```

I think jwt doesn't need to be an inout variable anymore